### PR TITLE
To avoid error when interface is configured but ip address is not

### DIFF
--- a/xpymon
+++ b/xpymon
@@ -148,6 +148,8 @@ class Monitor():
             self.last_iface = iface
             self.tx_bytes = self.rx_bytes = 0
             self.tx_rates = self.rx_rates = None
+        if iface is not None and addr is None:
+            addr = ''
         return iface, addr
 
     def wifi_status(self, iface):


### PR DESCRIPTION
In such situation, the output of *$ ip -oneline addr* is as follows in my environment,

> 1: lo    inet 127.0.0.1/8 scope host lo\       valid_lft forever preferred_lft forever
> 1: lo    inet6 ::1/128 scope host \       valid_lft forever preferred_lft forever
> 3: wlp2s0    inet6 2001:240:2415:5341:d66d:6dff:fe62:f070/64 scope global mngtmpaddr dynamic \       valid_lft forever preferred_lft forever

At this time, *wlp2s0* matched but *inet ([0-9.]+)* doesn't match anything. (*addr* become *None*)
This causes error on *compose_net_status*,

```python
        return '{:5} {:15} TX{:5.2f}{} RX{:5.2f}{}'.format(
            iface, addr, tx_base, tx_unit, rx_base, rx_unit)
```

Traceback (most recent call last):
  File "./xpymon", line 423, in <module>
    main()
  File "./xpymon", line 420, in main
    main_loop(disp, screen, window, width, gcs, monitor)
  File "./xpymon", line 368, in main_loop
    status_str = monitor.status_string(width / x11util.FONT_WIDTH)
  File "./xpymon", line 348, in status_string
    stats.append(self.compose_net_status(iface, addr))
  File "./xpymon", line 292, in compose_net_status
    iface, addr, tx_base, tx_unit, rx_base, rx_unit)
TypeError: unsupported format string passed to NoneType.__format__